### PR TITLE
TCPClient: share transaction id between packager and transporter

### DIFF
--- a/tcpclient.go
+++ b/tcpclient.go
@@ -43,6 +43,7 @@ type TCPClientHandler struct {
 func NewTCPClientHandler(address string) *TCPClientHandler {
 	transport := defaultTCPTransporter(address)
 	return &TCPClientHandler{
+		tcpPackager:    tcpPackager{transactionID: &transport.transactionID},
 		tcpTransporter: &transport,
 	}
 }
@@ -56,6 +57,7 @@ func TCPClient(address string) Client {
 // Clone creates a new client handler with the same underlying shared transport.
 func (mb *TCPClientHandler) Clone() *TCPClientHandler {
 	return &TCPClientHandler{
+		tcpPackager:    tcpPackager{transactionID: &mb.tcpTransporter.transactionID},
 		tcpTransporter: mb.tcpTransporter,
 	}
 }
@@ -63,7 +65,7 @@ func (mb *TCPClientHandler) Clone() *TCPClientHandler {
 // tcpPackager implements Packager interface.
 type tcpPackager struct {
 	// For synchronization between messages of server & client
-	transactionID uint32
+	transactionID *uint32
 	// Broadcast address is 0
 	SlaveID byte
 }
@@ -85,7 +87,7 @@ func (mb *tcpPackager) Encode(pdu *ProtocolDataUnit) (adu []byte, err error) {
 	adu = make([]byte, tcpHeaderSize+1+len(pdu.Data))
 
 	// Transaction identifier
-	transactionID := atomic.AddUint32(&mb.transactionID, 1)
+	transactionID := atomic.AddUint32(mb.transactionID, 1)
 	binary.BigEndian.PutUint16(adu, uint16(transactionID))
 	// Protocol identifier
 	binary.BigEndian.PutUint16(adu[2:], tcpProtocolIdentifier)
@@ -152,6 +154,9 @@ type tcpTransporter struct {
 
 	lastAttemptedTransactionID  uint16
 	lastSuccessfulTransactionID uint16
+
+	// For synchronization between messages of server & client
+	transactionID uint32
 }
 
 // defaultTCPTransporter creates a new tcpTransporter with default values.


### PR DESCRIPTION
Fix an issue with #5 where client re-creates transaction ids across different requests even if transport is shared