### PR TITLE
TCPClient: share transaction id between packager and transporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # go modbus
 Fault-tolerant, fail-fast implementation of Modbus protocol in Go.
 
+**Purpose:** this fork aims to enable modbus for concurrent usage. As such, it implements https://github.com/grid-x/modbus/pull/70.
+
 # Supported functions
 
 Bit access:

--- a/ascii_over_tcp_client.go
+++ b/ascii_over_tcp_client.go
@@ -11,22 +11,29 @@ import (
 // ASCIIOverTCPClientHandler implements Packager and Transporter interface.
 type ASCIIOverTCPClientHandler struct {
 	asciiPackager
-	asciiTCPTransporter
+	*asciiTCPTransporter
 }
 
 // NewASCIIOverTCPClientHandler allocates and initializes a ASCIIOverTCPClientHandler.
 func NewASCIIOverTCPClientHandler(address string) *ASCIIOverTCPClientHandler {
-	handler := &ASCIIOverTCPClientHandler{}
-	handler.Address = address
-	handler.Timeout = tcpTimeout
-	handler.IdleTimeout = tcpIdleTimeout
-	return handler
+	return &ASCIIOverTCPClientHandler{
+		asciiTCPTransporter: &asciiTCPTransporter{
+			defaultTCPTransporter(address),
+		},
+	}
 }
 
 // ASCIIOverTCPClient creates ASCII over TCP client with default handler and given connect string.
 func ASCIIOverTCPClient(address string) Client {
 	handler := NewASCIIOverTCPClientHandler(address)
 	return NewClient(handler)
+}
+
+// Clone creates a new client handler with the same underlying shared transport.
+func (mb *ASCIIOverTCPClientHandler) Clone() *ASCIIOverTCPClientHandler {
+	return &ASCIIOverTCPClientHandler{
+		asciiTCPTransporter: mb.asciiTCPTransporter,
+	}
 }
 
 // asciiTCPTransporter implements Transporter interface.

--- a/asciiclient.go
+++ b/asciiclient.go
@@ -25,22 +25,29 @@ var asciiStart = []string{":", ">"}
 // ASCIIClientHandler implements Packager and Transporter interface.
 type ASCIIClientHandler struct {
 	asciiPackager
-	asciiSerialTransporter
+	*asciiSerialTransporter
 }
 
 // NewASCIIClientHandler allocates and initializes a ASCIIClientHandler.
 func NewASCIIClientHandler(address string) *ASCIIClientHandler {
-	handler := &ASCIIClientHandler{}
-	handler.Address = address
-	handler.Timeout = serialTimeout
-	handler.IdleTimeout = serialIdleTimeout
-	return handler
+	return &ASCIIClientHandler{
+		asciiSerialTransporter: &asciiSerialTransporter{
+			serialPort: defaultSerialPort(address),
+		},
+	}
 }
 
 // ASCIIClient creates ASCII client with default handler and given connect string.
 func ASCIIClient(address string) Client {
 	handler := NewASCIIClientHandler(address)
 	return NewClient(handler)
+}
+
+// Clone creates a new client handler with the same underlying shared transport.
+func (mb *ASCIIClientHandler) Clone() *ASCIIClientHandler {
+	return &ASCIIClientHandler{
+		asciiSerialTransporter: mb.asciiSerialTransporter,
+	}
 }
 
 // asciiPackager implements Packager interface.

--- a/rtu_over_tcp_client.go
+++ b/rtu_over_tcp_client.go
@@ -12,22 +12,29 @@ import (
 // RTUOverTCPClientHandler implements Packager and Transporter interface.
 type RTUOverTCPClientHandler struct {
 	rtuPackager
-	rtuTCPTransporter
+	*rtuTCPTransporter
 }
 
 // NewRTUOverTCPClientHandler allocates and initializes a RTUOverTCPClientHandler.
 func NewRTUOverTCPClientHandler(address string) *RTUOverTCPClientHandler {
-	handler := &RTUOverTCPClientHandler{}
-	handler.Address = address
-	handler.Timeout = tcpTimeout
-	handler.IdleTimeout = tcpIdleTimeout
-	return handler
+	return &RTUOverTCPClientHandler{
+		rtuTCPTransporter: &rtuTCPTransporter{
+			defaultTCPTransporter(address),
+		},
+	}
 }
 
 // RTUOverTCPClient creates RTU over TCP client with default handler and given connect string.
 func RTUOverTCPClient(address string) Client {
 	handler := NewRTUOverTCPClientHandler(address)
 	return NewClient(handler)
+}
+
+// Clone creates a new client handler with the same underlying shared transport.
+func (mb *RTUOverTCPClientHandler) Clone() *RTUOverTCPClientHandler {
+	return &RTUOverTCPClientHandler{
+		rtuTCPTransporter: mb.rtuTCPTransporter,
+	}
 }
 
 // rtuTCPTransporter implements Transporter interface.

--- a/rtu_over_udp_client.go
+++ b/rtu_over_udp_client.go
@@ -24,20 +24,29 @@ func (length ErrADUResponseLength) Error() string {
 // RTUOverUDPClientHandler implements Packager and Transporter interface.
 type RTUOverUDPClientHandler struct {
 	rtuPackager
-	rtuUDPTransporter
+	*rtuUDPTransporter
 }
 
 // NewRTUOverUDPClientHandler allocates and initializes a RTUOverUDPClientHandler.
 func NewRTUOverUDPClientHandler(address string) *RTUOverUDPClientHandler {
-	handler := &RTUOverUDPClientHandler{}
-	handler.Address = address
-	return handler
+	return &RTUOverUDPClientHandler{
+		rtuUDPTransporter: &rtuUDPTransporter{
+			Address: address,
+		},
+	}
 }
 
 // RTUOverUDPClient creates RTU over UDP client with default handler and given connect string.
 func RTUOverUDPClient(address string) Client {
 	handler := NewRTUOverUDPClientHandler(address)
 	return NewClient(handler)
+}
+
+// Clone creates a new client handler with the same underlying shared transport.
+func (mb *RTUOverUDPClientHandler) Clone() *RTUOverUDPClientHandler {
+	return &RTUOverUDPClientHandler{
+		rtuUDPTransporter: mb.rtuUDPTransporter,
+	}
 }
 
 // rtuUDPTransporter implements Transporter interface.

--- a/rtuclient.go
+++ b/rtuclient.go
@@ -45,22 +45,29 @@ const (
 // RTUClientHandler implements Packager and Transporter interface.
 type RTUClientHandler struct {
 	rtuPackager
-	rtuSerialTransporter
+	*rtuSerialTransporter
 }
 
 // NewRTUClientHandler allocates and initializes a RTUClientHandler.
 func NewRTUClientHandler(address string) *RTUClientHandler {
-	handler := &RTUClientHandler{}
-	handler.Address = address
-	handler.Timeout = serialTimeout
-	handler.IdleTimeout = serialIdleTimeout
-	return handler
+	return &RTUClientHandler{
+		rtuSerialTransporter: &rtuSerialTransporter{
+			serialPort: defaultSerialPort(address),
+		},
+	}
 }
 
 // RTUClient creates RTU client with default handler and given connect string.
 func RTUClient(address string) Client {
 	handler := NewRTUClientHandler(address)
 	return NewClient(handler)
+}
+
+// Clone creates a new client handler with the same underlying shared transport.
+func (mb *RTUClientHandler) Clone() *RTUClientHandler {
+	return &RTUClientHandler{
+		rtuSerialTransporter: mb.rtuSerialTransporter,
+	}
 }
 
 // rtuPackager implements Packager interface.

--- a/serial.go
+++ b/serial.go
@@ -34,6 +34,17 @@ type serialPort struct {
 	closeTimer   *time.Timer
 }
 
+// defaultSerialPort creates a serialPort with default configuration.
+func defaultSerialPort(address string) serialPort {
+	return serialPort{
+		Config: serial.Config{
+			Address: address,
+			Timeout: serialTimeout,
+		},
+		IdleTimeout: serialIdleTimeout,
+	}
+}
+
 func (mb *serialPort) Connect() (err error) {
 	mb.mu.Lock()
 	defer mb.mu.Unlock()

--- a/tcpclient.go
+++ b/tcpclient.go
@@ -43,6 +43,7 @@ type TCPClientHandler struct {
 func NewTCPClientHandler(address string) *TCPClientHandler {
 	transport := defaultTCPTransporter(address)
 	return &TCPClientHandler{
+		tcpPackager:    tcpPackager{transactionID: &transport.transactionID},
 		tcpTransporter: &transport,
 	}
 }
@@ -56,6 +57,7 @@ func TCPClient(address string) Client {
 // Clone creates a new client handler with the same underlying shared transport.
 func (mb *TCPClientHandler) Clone() *TCPClientHandler {
 	return &TCPClientHandler{
+		tcpPackager:    tcpPackager{transactionID: &mb.tcpTransporter.transactionID},
 		tcpTransporter: mb.tcpTransporter,
 	}
 }
@@ -63,7 +65,7 @@ func (mb *TCPClientHandler) Clone() *TCPClientHandler {
 // tcpPackager implements Packager interface.
 type tcpPackager struct {
 	// For synchronization between messages of server & client
-	transactionID uint32
+	transactionID *uint32
 	// Broadcast address is 0
 	SlaveID byte
 }
@@ -85,7 +87,7 @@ func (mb *tcpPackager) Encode(pdu *ProtocolDataUnit) (adu []byte, err error) {
 	adu = make([]byte, tcpHeaderSize+1+len(pdu.Data))
 
 	// Transaction identifier
-	transactionID := atomic.AddUint32(&mb.transactionID, 1)
+	transactionID := atomic.AddUint32(mb.transactionID, 1)
 	binary.BigEndian.PutUint16(adu, uint16(transactionID))
 	// Protocol identifier
 	binary.BigEndian.PutUint16(adu[2:], tcpProtocolIdentifier)
@@ -152,6 +154,9 @@ type tcpTransporter struct {
 
 	lastAttemptedTransactionID  uint16
 	lastSuccessfulTransactionID uint16
+
+	// For synchronization between messages of server & client
+	transactionID uint32
 }
 
 // defaultTCPTransporter creates a new tcpTransporter with default values.


### PR DESCRIPTION
Fix an issue with https://github.com/evcc-io/modbus/pull/5 where client re-creates transaction ids across different requests even if transport is shared