### PR TITLE
Fix RTU timing

### DIFF
--- a/rtuclient.go
+++ b/rtuclient.go
@@ -181,8 +181,8 @@ func readIncrementally(slaveID, functionCode byte, r io.Reader, delay time.Durat
 			return nil, err
 		}
 
+		// after first byte, remaining bytes MUST be read within delay
 		if delay > 0 {
-			// after first byte, remaining bytes MUST be read within delay
 			deadline = time.Now().Add(delay)
 		}
 

--- a/rtuclient.go
+++ b/rtuclient.go
@@ -297,7 +297,7 @@ func (mb *rtuSerialTransporter) charBits() int {
 
 // charDuration returns time needed for a character to be transmitted.
 func (mb *rtuSerialTransporter) charsDuration(chars float64) time.Duration {
-	return time.Duration(chars*float64(mb.charBits())/float64(mb.BaudRate)) * time.Second
+	return time.Duration(chars*mb.charBits) * time.Second / mb.BaudRate
 }
 
 // frameDelay returns the minimum required delay between frames.

--- a/rtuclient.go
+++ b/rtuclient.go
@@ -303,10 +303,13 @@ func (mb *rtuSerialTransporter) charsDuration(chars float64) time.Duration {
 // frameDelay returns the minimum required delay between frames.
 // See MODBUS over Serial Line - Specification and Implementation Guide (page 13).
 func (mb *rtuSerialTransporter) frameDelay() time.Duration {
+	var frameDelay time.Duration // us
 	if mb.BaudRate <= 0 || mb.BaudRate > 19200 {
-		return time.Duration(1750) * time.Microsecond
+		frameDelay = time.Duration(1750) * time.Microsecond
+	} else {
+		frameDelay = mb.charsDuration(3.5)
 	}
-	return mb.charsDuration(3.5)
+	return frameDelay
 }
 
 func calculateResponseLength(adu []byte) int {

--- a/rtuclient.go
+++ b/rtuclient.go
@@ -290,7 +290,6 @@ func (mb *rtuSerialTransporter) charBits() int {
 	if mb.Parity != "N" {
 		parityBits++
 	}
-
 	return 1 + mb.DataBits + parityBits + mb.StopBits
 }
 
@@ -305,7 +304,6 @@ func (mb *rtuSerialTransporter) frameDelay() time.Duration {
 	if mb.BaudRate <= 0 || mb.BaudRate > 19200 {
 		return time.Duration(1750) * time.Microsecond
 	}
-
 	return mb.charsDuration(3.5)
 }
 

--- a/rtuclient.go
+++ b/rtuclient.go
@@ -268,7 +268,7 @@ func (mb *rtuSerialTransporter) Send(aduRequest []byte) (aduResponse []byte, err
 	mb.lastActivity = time.Now()
 	mb.startCloseTimer()
 
-	time.Sleep(time.Duration(3.5 * float64(mb.charDuration())))
+	time.Sleep(mb.charDuration(3.5))
 
 	// Send the request
 	mb.logf("modbus: send % x\n", aduRequest)
@@ -287,8 +287,8 @@ func (mb *rtuSerialTransporter) Send(aduRequest []byte) (aduResponse []byte, err
 }
 
 // charDuration returns time needed for a character to be transmitted.
-func (mb *rtuSerialTransporter) charDuration() time.Duration {
-	return time.Duration(float64((mb.DataBits+3)/mb.BaudRate)) * time.Second
+func (mb *rtuSerialTransporter) charDuration(chars float64) time.Duration {
+	return time.Duration(chars*float64(mb.DataBits+3)/float64(mb.BaudRate)) * time.Second
 }
 
 // calculateDelay roughly calculates time needed for the next frame.
@@ -297,11 +297,11 @@ func (mb *rtuSerialTransporter) calculateDelay(chars int) time.Duration {
 	var characterDelay, frameDelay time.Duration
 
 	if mb.BaudRate <= 0 || mb.BaudRate > 19200 {
-		characterDelay = mb.charDuration() + time.Duration(750)*time.Microsecond
+		characterDelay = mb.charDuration(1) + time.Duration(750)*time.Microsecond
 		frameDelay = time.Duration(1750) * time.Microsecond
 	} else {
-		characterDelay = mb.charDuration() + time.Duration(1.5*float64(mb.charDuration()))
-		frameDelay = time.Duration(3.5 * float64(mb.charDuration()))
+		characterDelay = mb.charDuration(2.5 * float64(chars))
+		frameDelay = mb.charDuration(3.5)
 	}
 	return characterDelay*time.Duration(chars) + frameDelay
 }

--- a/rtuclient.go
+++ b/rtuclient.go
@@ -290,6 +290,7 @@ func (mb *rtuSerialTransporter) Send(aduRequest []byte) (aduResponse []byte, err
 	data, err := readIncrementally(aduRequest[0], aduRequest[1], mb.port, time.Now().Add(mb.Config.Timeout))
 	mb.logf("modbus: recv % x\n", data[:])
 	aduResponse = data
+	time.Sleep(mb.frameDelay())
 	return
 }
 

--- a/rtuclient.go
+++ b/rtuclient.go
@@ -281,10 +281,7 @@ func (mb *rtuSerialTransporter) Send(aduRequest []byte) (aduResponse []byte, err
 
 	data, err := readIncrementally(aduRequest[0], aduRequest[1], mb.port, time.Now().Add(mb.Config.Timeout))
 	mb.logf("modbus: recv % x\n", data[:])
-
-	mb.lastActivity = time.Now()
-
-	return data, err
+	return
 }
 
 // charBits returns the number of bits per character.

--- a/rtuclient.go
+++ b/rtuclient.go
@@ -305,7 +305,7 @@ func (mb *rtuSerialTransporter) charsDuration(chars float64) time.Duration {
 func (mb *rtuSerialTransporter) frameDelay() time.Duration {
 	var frameDelay time.Duration // us
 	if mb.BaudRate <= 0 || mb.BaudRate > 19200 {
-		frameDelay = time.Duration(1750) * time.Microsecond
+		frameDelay = 1750 * time.Microsecond
 	} else {
 		frameDelay = mb.charsDuration(3.5)
 	}

--- a/rtuclient.go
+++ b/rtuclient.go
@@ -278,7 +278,7 @@ func (mb *rtuSerialTransporter) Send(aduRequest []byte) (aduResponse []byte, err
 	// function := aduRequest[1]
 	// functionFail := aduRequest[1] & 0x80
 	bytesToRead := calculateResponseLength(aduRequest)
-	time.Sleep(mb.charsDuration(float64(len(aduRequest)+bytesToRead)) + mb.frameDelay())
+	time.Sleep(mb.frameDelay() + mb.charsDuration(float64(len(aduRequest)+bytesToRead)))
 
 	data, err := readIncrementally(aduRequest[0], aduRequest[1], mb.port, time.Now().Add(mb.Config.Timeout))
 	mb.logf("modbus: recv % x\n", data[:])

--- a/rtuclient.go
+++ b/rtuclient.go
@@ -297,7 +297,7 @@ func (mb *rtuSerialTransporter) charBits() int {
 
 // charDuration returns time needed for a character to be transmitted.
 func (mb *rtuSerialTransporter) charsDuration(chars float64) time.Duration {
-	return time.Duration(chars*float64(mb.charBits())/float64(mb.BaudRate)) * time.Second
+	return time.Duration(chars * float64(mb.charBits()) * float64(time.Second) / float64(mb.BaudRate))
 }
 
 // frameDelay returns the minimum required delay between frames.

--- a/rtuclient.go
+++ b/rtuclient.go
@@ -297,7 +297,7 @@ func (mb *rtuSerialTransporter) charBits() int {
 
 // charDuration returns time needed for a character to be transmitted.
 func (mb *rtuSerialTransporter) charsDuration(chars float64) time.Duration {
-	return time.Duration(chars*mb.charBits) * time.Second / mb.BaudRate
+	return time.Duration(chars*float64(mb.charBits())/float64(mb.BaudRate)) * time.Second
 }
 
 // frameDelay returns the minimum required delay between frames.

--- a/rtuclient.go
+++ b/rtuclient.go
@@ -289,11 +289,12 @@ func (mb *rtuSerialTransporter) Send(aduRequest []byte) (aduResponse []byte, err
 
 // charBits returns the number of bits per character.
 func (mb *rtuSerialTransporter) charBits() int {
-	b := 1 + mb.DataBits + mb.StopBits
+	var parityBits int
 	if mb.Parity != "N" {
-		b++
+		parityBits++
 	}
-	return b
+
+	return 1 + mb.DataBits + parityBits + mb.StopBits
 }
 
 // charDuration returns time needed for a character to be transmitted.

--- a/rtuclient.go
+++ b/rtuclient.go
@@ -305,13 +305,13 @@ func (mb *rtuSerialTransporter) charDuration() time.Duration {
 // frameDelay returns the required minimum delay at the start and and the end of each frame.
 // See MODBUS over Serial Line - Specification and Implementation Guide (page 13).
 func (mb *rtuSerialTransporter) frameDelay() time.Duration {
-	var t int // µs
+	var fd int // µs
 	if mb.BaudRate <= 0 || mb.BaudRate > 19200 {
-		t = 1750
+		fd = 1750
 	} else {
-		t = 38500000 / mb.BaudRate
+		fd = 38500000 / mb.BaudRate
 	}
-	return time.Duration(t) * time.Microsecond
+	return time.Duration(fd) * time.Microsecond
 }
 
 func calculateResponseLength(adu []byte) int {

--- a/rtuclient.go
+++ b/rtuclient.go
@@ -275,7 +275,8 @@ func (mb *rtuSerialTransporter) Send(aduRequest []byte) (aduResponse []byte, err
 	if _, err = mb.port.Write(aduRequest); err != nil {
 		return
 	}
-
+	// function := aduRequest[1]
+	// functionFail := aduRequest[1] & 0x80
 	bytesToRead := calculateResponseLength(aduRequest)
 	time.Sleep(mb.charsDuration(float64(len(aduRequest)+bytesToRead)) + mb.frameDelay())
 

--- a/rtuclient.go
+++ b/rtuclient.go
@@ -287,7 +287,7 @@ func (mb *rtuSerialTransporter) Send(aduRequest []byte) (aduResponse []byte, err
 	}
 
 	// Wait for request to be sent
-	time.Sleep(mb.frameDelay() + time.Duration(len(aduRequest))*mb.charDuration())
+	time.Sleep(time.Duration(len(aduRequest))*mb.charDuration() + mb.frameDelay())
 
 	// Response is allowed to take character duration plus 1.5 characters gap (2.5 = 5/2 integer division)
 	responseDuration := time.Duration(calculateResponseLength(aduRequest)) * mb.charDuration() * 5 / 2

--- a/rtuclient.go
+++ b/rtuclient.go
@@ -181,7 +181,7 @@ func readIncrementally(slaveID, functionCode byte, r io.Reader, delay time.Durat
 			return nil, err
 		}
 
-		// after first byte, remaining bytes MUST be read within delay
+		// after response has started remaining bytes MUST be read within maximum message duration
 		if delay > 0 {
 			deadline = time.Now().Add(delay)
 		}

--- a/rtuclient.go
+++ b/rtuclient.go
@@ -281,6 +281,7 @@ func (mb *rtuSerialTransporter) Send(aduRequest []byte) (aduResponse []byte, err
 
 	data, err := readIncrementally(aduRequest[0], aduRequest[1], mb.port, time.Now().Add(mb.Config.Timeout))
 	mb.logf("modbus: recv % x\n", data[:])
+	aduResponse = data
 	return
 }
 

--- a/rtuclient_test.go
+++ b/rtuclient_test.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"reflect"
 	"testing"
-	"time"
 )
 
 func TestRTUEncoding(t *testing.T) {
@@ -331,7 +330,7 @@ func Test_readIncrementally(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.description, func(t *testing.T) {
-			got, err := readIncrementally(tc.slaveID, tc.functionCode, bytes.NewBuffer(tc.data), time.Now().Add(time.Second*5))
+			got, err := readIncrementally(tc.slaveID, tc.functionCode, bytes.NewBuffer(tc.data), 0)
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("expected error but did not get one")


### PR DESCRIPTION
Should fix https://github.com/evcc-io/evcc/issues/16049

It corrects the time calculation in two ways:

1. It ensures that the mandatory waiting time between consecutive frames (FrameDelay) according to the Modbus RTU specification is respected before a new request is sent on the bus.

2. It corrects the calculation of the minimum transmission RTT taking into account the serial parameters and the corresponding FrameDelay value.